### PR TITLE
Don't imply `this` return value for `addModule` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ let workerBlock = module {
   }
 };
 
-let worker = new Worker({type: "module"}).addModule(workerBlock);
+let worker = new Worker({type: "module"});
+worker.addModule(workerBlock);
 worker.onmessage = ({data}) => alert(data);
 worker.postMessage(module { export default function() { return "hello!" } });
 ```


### PR DESCRIPTION
By putting the `addModule` call on its own line in this example the code example implies less about how it works, leaving open possibilities for stuff like this in the reader's imagination: https://github.com/whatwg/html/issues/6911#issuecomment-952768349

Please feel free to close this if it's too trite (since this proposal isn't about the inner workings of `addModule`). Just making this suggestion because I'm excited about the ideas discussed in the previously-linked issue. Thanks!